### PR TITLE
Make DGraph skin compatible with 1.36

### DIFF
--- a/Dgraph/DgraphTemplate.php
+++ b/Dgraph/DgraphTemplate.php
@@ -60,7 +60,7 @@ class DgraphTemplate extends BaseTemplate {
 
 				$xmlID = isset( $link['id'] ) ? $link['id'] : 'ca-' . $xmlID;
 				$nav[$section][$key]['attributes'] =
-					' id="' . Sanitizer::escapeId( $xmlID ) . '"';
+					' id="' . Sanitizer::escapeIdForAttribute( $xmlID ) . '"';
 				if ( $link['class'] ) {
 					$nav[$section][$key]['attributes'] .=
 						' class="' . htmlspecialchars( $link['class'] ) . '"';
@@ -428,10 +428,10 @@ class DgraphTemplate extends BaseTemplate {
 			$msg = $name;
 		}
 		$msgObj = wfMessage( $msg );
-		$labelId = Sanitizer::escapeId( "p-$name-label" );
+		$labelId = Sanitizer::escapeIdForAttribute( "p-$name-label" );
 		?>
 		<div class="portal" role="navigation" id='<?php
-		echo Sanitizer::escapeId( "p-$name" )
+		echo Sanitizer::escapeIdForAttribute( "p-$name" )
 		?>'<?php
 		echo Linker::tooltip( 'p-' . $name )
 		?> aria-labelledby='<?php echo $labelId ?>'>

--- a/Dgraph/SkinDgraph.php
+++ b/Dgraph/SkinDgraph.php
@@ -33,15 +33,16 @@ class SkinDgraph extends SkinTemplate {
 	/**
 	 * @var Config
 	 */
-	private $vectorConfig;
+	private $dConfig;
 
-	public function __construct() {
-		$this->vectorConfig = ConfigFactory::getDefaultInstance()->makeConfig( 'vector' );
-	}
+	public function __construct( $options = [] ) {
+		$this->dConfig = ConfigFactory::getDefaultInstance()->makeConfig( 'vector' );
 
-	// Dgraph Stuff
-	function addToBodyAttributes( $out, &$bodyAttrs ) {
-		$bodyAttrs['class'] = 'page';
+		if ( $this->dConfig->get( 'DgraphResponsive' ) ) {
+			$options['responsive'] = true;
+			$options['styles'][] = 'skins.dgraph.styles.responsive';
+		}
+		parent::__construct( $options );
 	}
 
 	/**
@@ -50,11 +51,6 @@ class SkinDgraph extends SkinTemplate {
 	 */
 	public function initPage( OutputPage $out ) {
 		parent::initPage( $out );
-
-		if ( $this->vectorConfig->get( 'VectorResponsive' ) ) {
-			$out->addMeta( 'viewport', 'width=device-width, initial-scale=1' );
-			$out->addModuleStyles( 'skins.vector.styles.responsive' );
-		}
 
 		// Append CSS which includes IE only behavior fixes for hover support -
 		// this is better than including this in a CSS file since it doesn't
@@ -76,26 +72,12 @@ class SkinDgraph extends SkinTemplate {
 				htmlspecialchars( $this->getConfig()->get( 'LocalStylePath' ) ) .
 				'/' . $this->stylename . '/assets/js/modernizr.min.js"></script>'
 		);
-
-		$out->addModules( array( 'skins.vector.js' ) );
-	}
-
-	/**
-	 * Loads skin and user CSS files.
-	 * @param OutputPage $out
-	 */
-	function setupSkinUserCss( OutputPage $out ) {
-		parent::setupSkinUserCss( $out );
-
-		$styles = array( 'mediawiki.skinning.interface', 'skins.vector.styles' );
-		Hooks::run( 'SkinVectorStyleModules', array( $this, &$styles ) );
-		$out->addModuleStyles( $styles );
 	}
 
 	/**
 	 * Override to pass our Config instance to it
 	 */
 	public function setupTemplate( $classname, $repository = false, $cache_dir = false ) {
-		return new $classname( $this->vectorConfig );
+		return new $classname( $this->dConfig );
 	}
 }

--- a/Dgraph/skin.json
+++ b/Dgraph/skin.json
@@ -12,8 +12,24 @@
 	"ConfigRegistry": {
 		"dgraph": "GlobalVarConfig::newInstance"
 	},
+	"requires": {
+		"MediaWiki": ">= 1.36.0"
+	},
 	"ValidSkinNames": {
-		"dgraph": "Dgraph"
+		"dgraph": {
+			"class": "SkinDgraph",
+			"args": [
+				{
+					"name": "dgraph",
+					"template": "DgraphTemplate",
+					"styles": [
+						"skins.dgraph.styles"
+					],
+					"scripts": [
+					]
+				}
+			]
+		}
 	},
 	"MessagesDirs": {
 		"Dgraph": [
@@ -27,6 +43,7 @@
 	"@note": "When modifying skins.dgraph.styles definition, make sure the installer still works",
 	"ResourceModules": {
 		"skins.dgraph.styles": {
+			"class": "ResourceLoaderSkinModule",
 			"position": "top",
 			"styles": {
 				"screen.less": {


### PR DESCRIPTION
I would love to have this skin featured on https://skins.wmflabs.org/?#/skin/dgraph but to do that I need to make it compatible with 1.36

1.36 simplifies a lot of things.

Styles from mediawiki.skinning.interface come from ResourceLoaderSkinModule

I've dropped the Vector module references. those will likely break in 1.36 and don't seem to be necessary. Can amend patch to conditionally add them if needed.
